### PR TITLE
Fix: DNSResult::type contains the original type id not the type name as expected

### DIFF
--- a/dns.php
+++ b/dns.php
@@ -82,7 +82,7 @@ if ($query->hasError()) {
 echo "Returned ".count($result)." Answers\n";
 
 foreach ($result as $index => $record) {
-    echo $index . ". " . $record->getTypeid() . "(" . $record->getType() . ") => " . $record->getData() . " [";
+    echo $index . ". " . $record->getTypeid() . "(" . $record->getTypename() . ") => " . $record->getData() . " [";
     echo $record->getString();
     echo "]\n";
 

--- a/index.php
+++ b/index.php
@@ -132,7 +132,7 @@ function ShowSection(DNSAnswer $result)
         echo $index.". ";
 
         if ($record->getString()=="") {
-            echo $record->getTypeid() . "(" . $record->getType() . ") => " . $record->getData();
+            echo $record->getTypeid() . "(" . $record->getTypename() . ") => " . $record->getData();
         } else {
             echo $record->getString();
         }
@@ -140,7 +140,7 @@ function ShowSection(DNSAnswer $result)
         echo "\n";
 
         if ($extendanswer) {
-            echo " - record type = ".$record->getTypeid()." (# ".$record->getType().")\n";
+            echo " - record type = ".$record->getTypeid()." (# ".$record->getTypename().")\n";
             echo " - record data = ".$record->getData()."\n";
             echo " - record ttl = ".$record->getTtl()."\n";
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="true"
+         bootstrap="../_ORMFramework_develop/phpunit_bootstrap.php"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./App/</directory>
+        </include>
+    </coverage>
+    <testsuites>
+        <testsuite name="App Test Suite">
+            <directory>./AppTests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/PurplePixie/PhpDns/DNSResult.php
+++ b/src/PurplePixie/PhpDns/DNSResult.php
@@ -24,7 +24,7 @@ namespace PurplePixie\PhpDns;
  */
 class DNSResult
 {
-    private string $type;
+    private string $typename;
 
     private int $typeid;
 
@@ -40,9 +40,9 @@ class DNSResult
 
     private array $extras;
 
-    public function __construct(string $type, int $typeid, string $class, int $ttl, string $data, string $domain, string $string, array $extras)
+    public function __construct(string $typename, int $typeid, string $class, int $ttl, string $data, string $domain, string $string, array $extras)
     {
-        $this->type = $type;
+        $this->typename = $typename;
         $this->typeid = $typeid;
         $this->class = $class;
         $this->ttl = $ttl;
@@ -52,9 +52,21 @@ class DNSResult
         $this->extras = $extras;
     }
 
+    /**
+     * @deprecated
+     * @return string
+     */
     public function getType(): string
     {
-        return $this->type;
+        return $this->typename;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTypename(): string
+    {
+        return $this->typename;
     }
 
     public function getTypeid(): int

--- a/src/PurplePixie/PhpDns/DNSTypes.php
+++ b/src/PurplePixie/PhpDns/DNSTypes.php
@@ -6,6 +6,7 @@ namespace PurplePixie\PhpDns;
  * This file is the PurplePixie PHP DNS Types Class
  *
  * The software is (C) Copyright 2008-16 PurplePixie Systems
+ * Copyright (C) 2022, Fabian Bett / Bett Ingenieure GmbH
  *
  * This is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,62 +25,148 @@ namespace PurplePixie\PhpDns;
  */
 class DNSTypes
 {
+    const ID_A = 1;
+    const ID_NS = 2;
+    const ID_CNAME = 5;
+    const ID_SOA = 6;
+    const ID_PTR = 12;
+    const ID_MX = 15;
+    const ID_TXT = 16;
+    const ID_RP = 17;
+    const ID_AFSDB = 18;
+    const ID_SIG = 24;
+    const ID_KEY = 25;
+    const ID_AAAA = 28;
+    const ID_LOC = 29;
+    const ID_SRV = 33;
+    const ID_NAPTR = 35;
+    const ID_KX = 36;
+    const ID_CERT = 37;
+    const ID_DNAME = 39;
+    const ID_APL = 42;
+    const ID_DS = 43;
+    const ID_SSHFP = 44;
+    const ID_IPSECKEY = 45;
+    const ID_RRSIG = 46;
+    const ID_NSEC = 47;
+    const ID_DNSKEY = 48;
+    const ID_DHCID = 49;
+    const ID_NSEC3 = 50;
+    const ID_NSEC3PARAM = 51;
+    const ID_HIP = 55;
+    const ID_SPF = 99;
+    const ID_TKEY = 249;
+    const ID_TSIG = 250;
+    const ID_IXFR = 251;
+    const ID_AXFR = 252;
+    const ID_ANY = 255;
+    const ID_TA = 32768;
+    const ID_DLV = 32769;
+
+    const NAME_A = 'A';
+    const NAME_NS = 'NS';
+    const NAME_CNAME = 'CNAME';
+    const NAME_SOA = 'SOA';
+    const NAME_PTR = 'PTR';
+    const NAME_MX = 'MX';
+    const NAME_TXT = 'TXT';
+    const NAME_RP = 'RP';
+    const NAME_AFSDB = 'AFSDB';
+    const NAME_SIG = 'SIG';
+    const NAME_KEY = 'KEY';
+    const NAME_AAAA = 'AAAA';
+    const NAME_LOC = 'LOC';
+    const NAME_SRV = 'SRV';
+    const NAME_NAPTR = 'NAPTR';
+    const NAME_KX = 'KX';
+    const NAME_CERT = 'CERT';
+    const NAME_DNAME = 'DNAME';
+    const NAME_APL = 'APL';
+    const NAME_DS = 'DS';
+    const NAME_SSHFP = 'SSHFP';
+    const NAME_IPSECKEY = 'IPSECKEY';
+    const NAME_RRSIG = 'RRSIG';
+    const NAME_NSEC = 'NSEC';
+    const NAME_DNSKEY = 'DNSKEY';
+    const NAME_DHCID = 'DHCID';
+    const NAME_NSEC3 = 'NSEC3';
+    const NAME_NSEC3PARAM = 'NSEC3PARAM';
+    const NAME_HIP = 'HIP';
+    const NAME_SPF = 'SPF';
+    const NAME_TKEY = 'TKEY';
+    const NAME_TSIG = 'TSIG';
+    const NAME_IXFR = 'IXFR';
+    const NAME_AXFR = 'AXFR';
+    const NAME_ANY = 'ANY';
+    const NAME_TA = 'TA';
+    const NAME_DLV = 'DLV';
+
     private array $types = [
-        1 => 'A', // RFC 1035 (Address Record)
-        2 => 'NS', // RFC 1035 (Name Server Record)
-        5 => 'CNAME', // RFC 1035 (Canonical Name Record (Alias))
-        6 => 'SOA', // RFC 1035 (Start of Authority Record)
-        12 => 'PTR', // RFC 1035 (Pointer Record)
-        15 => 'MX', // RFC 1035 (Mail eXchanger Record)
-        16 => 'TXT', // RFC 1035 (Text Record)
-        17 => 'RP', // RFC 1183 (Responsible Person)
-        18 => 'AFSDB', // RFC 1183 (AFS Database Record)
-        24 => 'SIG', // RFC 2535
-        25 => 'KEY', // RFC 2535 & RFC 2930
-        28 => 'AAAA', // RFC 3596 (IPv6 Address)
-        29 => 'LOC', // RFC 1876 (Geographic Location)
-        33 => 'SRV', // RFC 2782 (Service Locator)
-        35 => 'NAPTR', // RFC 3403 (Naming Authority Pointer)
-        36 => 'KX', // RFC 2230 (Key eXchanger)
-        37 => 'CERT', // RFC 4398 (Certificate Record, PGP etc)
-        39 => 'DNAME', // RFC 2672 (Delegation Name Record, wildcard alias)
-        42 => 'APL', // RFC 3123 (Address Prefix List (Experimental)
-        43 => 'DS', // RFC 4034 (Delegation Signer (DNSSEC)
-        44 => 'SSHFP', // RFC 4255 (SSH Public Key Fingerprint)
-        45 => 'IPSECKEY', // RFC 4025 (IPSEC Key)
-        46 => 'RRSIG', // RFC 4034 (DNSSEC Signature)
-        47 => 'NSEC', // RFC 4034 (Next-secure Record (DNSSEC))
-        48 => 'DNSKEY', // RFC 4034 (DNS Key Record (DNSSEC))
-        49 => 'DHCID', // RFC 4701 (DHCP Identifier)
-        50 => 'NSEC3', // RFC 5155 (NSEC Record v3 (DNSSEC Extension))
-        51 => 'NSEC3PARAM', // RFC 5155 (NSEC3 Parameters (DNSSEC Extension))
-        55 => 'HIP', // RFC 5205 (Host Identity Protocol)
-        99 => 'SPF', // RFC 4408 (Sender Policy Framework)
-        249 => 'TKEY', // RFC 2930 (Secret Key)
-        250 => 'TSIG', // RFC 2845 (Transaction Signature)
-        251 => 'IXFR', // RFC 1995 (Incremental Zone Transfer)
-        252 => 'AXFR', // RFC 1035 (Authoritative Zone Transfer)
-        255 => 'ANY', // RFC 1035 AKA "*" (Pseudo Record)
-        32768 => 'TA', // (DNSSEC Trusted Authorities)
-        32769 => 'DLV', // RFC 4431 (DNSSEC Lookaside Validation)
+        self::ID_A => self::NAME_A, // RFC 1035 (Address Record)
+        self::ID_NS => self::NAME_NS, // RFC 1035 (Name Server Record)
+        self::ID_CNAME => self::NAME_CNAME, // RFC 1035 (Canonical Name Record (Alias))
+        self::ID_SOA => self::NAME_SOA, // RFC 1035 (Start of Authority Record)
+        self::ID_PTR => self::NAME_PTR, // RFC 1035 (Pointer Record)
+        self::ID_MX => self::NAME_MX, // RFC 1035 (Mail eXchanger Record)
+        self::ID_TXT => self::NAME_TXT, // RFC 1035 (Text Record)
+        self::ID_RP => self::NAME_RP, // RFC 1183 (Responsible Person)
+        self::ID_AFSDB => self::NAME_AFSDB, // RFC 1183 (AFS Database Record)
+        self::ID_SIG => self::NAME_SIG, // RFC 2535
+        self::ID_KEY => self::NAME_KEY, // RFC 2535 & RFC 2930
+        self::ID_AAAA => self::NAME_AAAA, // RFC 3596 (IPv6 Address)
+        self::ID_LOC => self::NAME_LOC, // RFC 1876 (Geographic Location)
+        self::ID_SRV => self::NAME_SRV, // RFC 2782 (Service Locator)
+        self::ID_NAPTR => self::NAME_NAPTR, // RFC 3403 (Naming Authority Pointer)
+        self::ID_KX => self::NAME_KX, // RFC 2230 (Key eXchanger)
+        self::ID_CERT => self::NAME_CERT, // RFC 4398 (Certificate Record, PGP etc)
+        self::ID_DNAME => self::NAME_DNAME, // RFC 2672 (Delegation Name Record, wildcard alias)
+        self::ID_APL => self::NAME_APL, // RFC 3123 (Address Prefix List (Experimental)
+        self::ID_DS => self::NAME_DS, // RFC 4034 (Delegation Signer (DNSSEC)
+        self::ID_SSHFP => self::NAME_SSHFP, // RFC 4255 (SSH Public Key Fingerprint)
+        self::ID_IPSECKEY => self::NAME_IPSECKEY, // RFC 4025 (IPSEC Key)
+        self::ID_RRSIG => self::NAME_RRSIG, // RFC 4034 (DNSSEC Signature)
+        self::ID_NSEC => self::NAME_NSEC, // RFC 4034 (Next-secure Record (DNSSEC))
+        self::ID_DNSKEY => self::NAME_DNSKEY, // RFC 4034 (DNS Key Record (DNSSEC))
+        self::ID_DHCID => self::NAME_DHCID, // RFC 4701 (DHCP Identifier)
+        self::ID_NSEC3 => self::NAME_NSEC3, // RFC 5155 (NSEC Record v3 (DNSSEC Extension))
+        self::ID_NSEC3PARAM => self::NAME_NSEC3PARAM, // RFC 5155 (NSEC3 Parameters (DNSSEC Extension))
+        self::ID_HIP => self::NAME_HIP, // RFC 5205 (Host Identity Protocol)
+        self::ID_SPF => self::NAME_SPF, // RFC 4408 (Sender Policy Framework)
+        self::ID_TKEY => self::NAME_TKEY, // RFC 2930 (Secret Key)
+        self::ID_TSIG => self::NAME_TSIG, // RFC 2845 (Transaction Signature)
+        self::ID_IXFR => self::NAME_IXFR, // RFC 1995 (Incremental Zone Transfer)
+        self::ID_AXFR => self::NAME_AXFR, // RFC 1035 (Authoritative Zone Transfer)
+        self::ID_ANY => self::NAME_ANY, // RFC 1035 AKA "*" (Pseudo Record)
+        self::ID_TA =>  self::NAME_TA, // (DNSSEC Trusted Authorities)
+        self::ID_DLV => self::NAME_DLV, // RFC 4431 (DNSSEC Lookaside Validation)
     ];
 
-    public function getByName(string $name): int
+    /**
+     * @param string $name
+     * @return int
+     * @throws Exceptions\InvalidQueryTypeName
+     */
+    public function getIdFromName(string $name): int
     {
-        if (false !== $index = array_search($name, $this->types, true)) {
+        if ( false !== $index = array_search($name, $this->types, true)) {
             return $index;
         }
 
-        return 0;
+        throw new Exceptions\InvalidQueryTypeName($name);
     }
 
-    public function getById(int $id): string
+    /**
+     * @param int $id
+     * @return string
+     * @throws Exceptions\InvalidQueryTypeId
+     */
+    public function getNameById(int $id): string
     {
         if (isset($this->types[$id])) {
             return $this->types[$id];
         }
 
-        return '';
+        throw new Exceptions\InvalidQueryTypeId($id);
     }
 
     public function getAllTypeNamesSorted(): array

--- a/src/PurplePixie/PhpDns/Exceptions/InvalidQueryTypeId.php
+++ b/src/PurplePixie/PhpDns/Exceptions/InvalidQueryTypeId.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Copyright (C) 2022, Fabian Bett / Bett Ingenieure GmbH
+ *
+ * This is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.  If not, see www.gnu.org/licenses
+ *
+ * For more information see www.purplepixie.org/phpdns
+ */
+
+namespace PurplePixie\PhpDns\Exceptions;
+
+class InvalidQueryTypeId extends \Exception {
+
+    public function __construct(string $typeId) {
+        parent::__construct('Invalid query type id: ' . $typeId);
+    }
+}

--- a/src/PurplePixie/PhpDns/Exceptions/InvalidQueryTypeName.php
+++ b/src/PurplePixie/PhpDns/Exceptions/InvalidQueryTypeName.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Copyright (C) 2022, Fabian Bett / Bett Ingenieure GmbH
+ *
+ * This is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.  If not, see www.gnu.org/licenses
+ *
+ * For more information see www.purplepixie.org/phpdns
+ */
+
+namespace PurplePixie\PhpDns\Exceptions;
+
+class InvalidQueryTypeName extends \Exception {
+
+    public function __construct(string $typeName) {
+        parent::__construct('Invalid query type name: ' . $typeName);
+    }
+}

--- a/tests/DNSQueryTest.php
+++ b/tests/DNSQueryTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Copyright (C) 2022, Fabian Bett / Bett Ingenieure GmbH
+ *
+ * This is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.  If not, see www.gnu.org/licenses
+ *
+ * For more information see www.purplepixie.org/phpdns
+ */
+
+use PHPUnit\Framework\TestCase;
+
+use PurplePixie\PhpDns\DNSQuery;
+
+class DNSQueryTest extends TestCase
+{
+    /**
+     * @covers \PurplePixie\PhpDns\DNSQuery::query
+     * @covers \PurplePixie\PhpDns\DNSTypes::getIdFromName
+     */
+    public function testInvalidDNSTypeName(): void
+    {
+        $query = new DNSQuery("8.8.8.8");
+        $this->expectException(\PurplePixie\PhpDns\Exceptions\InvalidQueryTypeName::class);
+        $query->query('google.com', 'invalid');
+    }
+
+    public function testALookup() : void {
+
+        $query = new DNSQuery("8.8.8.8");
+        $queryResult = $query->query('google.com', \PurplePixie\PhpDns\DNSTypes::NAME_A);
+        $this->assertTrue($queryResult->count() > 0);
+
+        foreach($queryResult as $entry) {
+
+            // TODO: What is the expected class?
+            //$this->assertEquals("1", $entry->getClass());
+
+            $this->assertTrue(
+                $entry->getData() != ''
+                && strpos($entry->getData(), '.') !== false,
+                'Result: ' . $entry->getData(),
+            );
+
+            $this->assertEquals('google.com', $entry->getDomain());
+
+            $this->assertTrue(is_array($entry->getExtras()));
+            // TODO: Test extra array
+
+            $this->assertTrue( strpos($entry->getString(),'google.com has IPv4 address ') === 0, 'Result: ' . $entry->getString());
+            $this->assertEquals(\PurplePixie\PhpDns\DNSTypes::NAME_A, $entry->getTypename());
+            $this->assertEquals(\PurplePixie\PhpDns\DNSTypes::ID_A, $entry->getTypeid());
+            $this->assertTrue(is_numeric($entry->getTtl()), $entry->getTtl());
+        }
+    }
+
+    public function testASmartLookup() : void {
+
+        $query = new DNSQuery("8.8.8.8");
+        $queryResult = $query->smartALookup('google.com');
+        $this->assertTrue(
+            $queryResult != ""
+            && strpos($queryResult, '.') !== false,
+            'Result: ' . $queryResult,
+        );
+    }
+
+    public function testAAAALookup() : void {
+
+        $query = new DNSQuery("8.8.8.8");
+        $queryResult = $query->query('google.com', \PurplePixie\PhpDns\DNSTypes::NAME_AAAA);
+        $this->assertTrue($queryResult->count() > 0);
+
+        foreach($queryResult as $entry) {
+
+            // TODO: What is the expected class?
+            //$this->assertEquals("1", $entry->getClass());
+
+            $this->assertTrue(
+                $entry->getData() != ''
+                && strpos($entry->getData(), ':') !== false,
+                'Result: ' . $entry->getData(),
+            );
+
+            $this->assertEquals('google.com', $entry->getDomain());
+
+            $this->assertTrue(is_array($entry->getExtras()));
+            // TODO: Test extra array
+
+            $this->assertTrue( strpos($entry->getString(),'google.com has IPv6 address ') === 0, 'Result: ' . $entry->getString());
+            $this->assertEquals(\PurplePixie\PhpDns\DNSTypes::NAME_AAAA, $entry->getTypename());
+            $this->assertEquals(\PurplePixie\PhpDns\DNSTypes::ID_AAAA, $entry->getTypeid());
+            $this->assertTrue(is_numeric($entry->getTtl()), $entry->getTtl());
+        }
+    }
+}


### PR DESCRIPTION
Hi,

thank you for your current pull requests.

I found a problem with the DNSType/ID change:
- The field DNSResult::type contains the original type id, not the type name
- The field DNSResult::typeid contains the same id as in DNSResult::type (received from DNSTypes)

As a result, DNSQuery::smartALookup is not working anymore, because type ids should match type names, which is not working.

I would assume, that is not your fault: The library has handled the type name/id wrongly mixed.

This fix includes:
- Refactored DNSTypes by using constants
- Bugfix for DNSQuery
- Unit tests

To raise the code quality, some additional changes were made:
- Exceptions when an invalid/unknown query type name/id is given (instead of returning an empty string and without handling this call on every call)
- Some renames to clarify the usage, like DNSTypes::getByName => DNSTypes::getIdByName